### PR TITLE
feat: add custom 500 error page and update exception handling

### DIFF
--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -19,4 +19,11 @@ return Application::configure(basePath: dirname(__DIR__))
         $exceptions->render(function (NotFoundHttpException $e, $request) {
             return response()->view('errors.404', [], 404);
         });
+
+        // Handle 500 errors
+        $exceptions->render(function (Exception $e, $request) {
+            if ($e instanceof \ErrorException || $e instanceof \Error) {
+                return response()->view('errors.500', [], 500);
+            }
+        });
     })->create();

--- a/resources/views/errors/500.blade.php
+++ b/resources/views/errors/500.blade.php
@@ -5,30 +5,34 @@
     <div class="row justify-content-center">
         <div class="col-md-8 text-center">
             <div class="error-template">
-                <h1 class="display-1 text-muted">404</h1>
-                <h2 class="mb-4">Page Not Found</h2>
+                <h1 class="display-1 text-danger">500</h1>
+                <h2 class="mb-4">Internal Server Error</h2>
                 <p class="lead mb-4">
-                    Sorry, the page you are looking for could not be found.
+                    Something went wrong on our end. We're working to fix it!
                 </p>
                 <div class="error-actions">
                     <a href="{{ url('/') }}" class="btn btn-primary btn-lg me-2">
                         <i class="bi bi-house me-2"></i>Go to Home page
                     </a>
-                    <a href="{{ route('posts.index') }}" class="btn btn-outline-secondary btn-lg">
-                        <i class="bi bi-file-text me-2"></i>View Posts
-                    </a>
+                    <button onclick="history.back()" class="btn btn-outline-secondary btn-lg">
+                        <i class="bi bi-arrow-left me-2"></i>Go Back
+                    </button>
                 </div>
                 
                 <div class="mt-5">
-                    <h5>What can you do?</h5>
+                    <h5>What happened?</h5>
                     <ul class="list-unstyled">
-                        <li><i class="bi bi-arrow-right text-primary"></i> Check if you typed the URL correctly</li>
-                        <li><i class="bi bi-arrow-right text-primary"></i> Go back to the <a href="{{ url('/') }}">homepage</a></li>
-                        <li><i class="bi bi-arrow-right text-primary"></i> Browse our <a href="{{ route('posts.index') }}">posts</a></li>
-                        @guest
-                        <li><i class="bi bi-arrow-right text-primary"></i> <a href="{{ route('login') }}">Sign in</a> to access more content</li>
-                        @endguest
+                        <li><i class="bi bi-exclamation-triangle text-warning"></i> A server error occurred while processing your request</li>
+                        <li><i class="bi bi-tools text-primary"></i> Our team has been notified and is working on a fix</li>
+                        <li><i class="bi bi-arrow-clockwise text-primary"></i> Try refreshing the page in a few moments</li>
+                        <li><i class="bi bi-arrow-right text-primary"></i> If the problem persists, go back to the <a href="{{ url('/') }}">homepage</a></li>
                     </ul>
+                </div>
+                
+                <div class="mt-4">
+                    <p class="text-muted small">
+                    <!--    Error Code: 500 | {{ now()->format('Y-m-d H:i:s') }} -->
+                    </p>
                 </div>
             </div>
         </div>

--- a/routes/web.php
+++ b/routes/web.php
@@ -54,4 +54,13 @@ Route::middleware('auth')->group(function () {
     Route::delete('/profile', [ProfileController::class, 'destroy'])->name('profile.destroy');
 });
 
+// Test routes for error pages (remove in production)
+Route::get('/test-404', function () {
+    abort(404);
+})->name('test.404');
+
+Route::get('/test-500', function () {
+    abort(500);
+})->name('test.500');
+
 require __DIR__.'/auth.php';


### PR DESCRIPTION
This pull request introduces enhanced error handling and user-friendly error pages for 404 and 500 HTTP errors. It includes changes to render custom views for these errors, updates to the 404 error page text, and the addition of a new 500 error page with detailed information and styling. Test routes for these error pages have also been added for development purposes.

### Error Handling Enhancements:
* [`bootstrap/app.php`](diffhunk://#diff-10bc2462d34ebc59a5d482a1faca04ce74f6df89fcc2ef8bfb17b939647ea518R22-R28): Added logic to handle 500 errors by rendering a custom view (`errors.500`) when exceptions of type `ErrorException` or `Error` occur.

### Error Page Updates:
* [`resources/views/errors/404.blade.php`](diffhunk://#diff-68172ed31c58d21c420da9c9ca6ca4b1e81635111b0df0c10ccce04ac8150e2fL15-R15): Updated the button text from "Go Home" to "Go to Home page" for consistency and clarity.
* [`resources/views/errors/500.blade.php`](diffhunk://#diff-66941da8f1c9be5b3a9fd1df1f6121f2e4e2efcdd577aea5e0dcbfb1381da484R1-R94): Created a new custom 500 error page with detailed messaging, navigation options, and responsive styling. Includes explanations for users and suggestions for resolving the issue.

### Development Utilities:
* [`routes/web.php`](diffhunk://#diff-193e04aa1705f6f3e484d7efca8f45fe4d19d0ece3b6e6880d3ea070938a1fadR57-R65): Added test routes (`/test-404` and `/test-500`) to simulate 404 and 500 errors for development and testing purposes. These routes should be removed in production.